### PR TITLE
Fix network middleware code example

### DIFF
--- a/guide/advanced/net-middlewares.md
+++ b/guide/advanced/net-middlewares.md
@@ -86,7 +86,7 @@ const client = new TelegramClient({
                     logPeerIdInvalid(ctx.request)
                 }
             }),
-            networkMiddlewares.basic()
+            ...networkMiddlewares.basic()
         ]
     }
 })

--- a/guide/intro/faq.md
+++ b/guide/intro/faq.md
@@ -224,7 +224,7 @@ const tg = new TelegramClient({
             tg.close()
           }
         }),
-        networkMiddlewares.basic()
+        ...networkMiddlewares.basic()
       ]
     }
 })


### PR DESCRIPTION
Currently it raises a TypeScript error:

```
Type 'RpcCallMiddleware[]' is not assignable to type 'Middleware<RpcCallMiddlewareContext, unknown>'.
  Type 'RpcCallMiddleware[]' provides no match for the signature '(ctx: RpcCallMiddlewareContext, next: (ctx: RpcCallMiddlewareContext) => Promise<unknown>): Promise<unknown>'.ts(2322)
```